### PR TITLE
Add random colors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     name: "LoremIpsum",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v9),
         .watchOS(.v2),
         .tvOS(.v9)
     ],

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project was inspired by a great static site generator [Middleman](http://gi
 - [Usage](#usage)
     - [Texts](#texts)
     - [Misc Data](#misc-data)
+    - [Colors](#colors)
     - [Images](#images)
 - [Example Projects](#example-projects)
 - [Author](#author)
@@ -98,6 +99,16 @@ let email = LoremIpsum.email // => "jared.finch@hotmail.com"
 let url: URL = LoremIpsum.URL // => "http://stumbleupon.com/"
 let tweet: String = LoremIpsum.tweet
 let date = LoremIpsum.date
+```
+
+### Colors
+
+*Lorem Ipsum* supports creating random colors.
+
+```objective-c
+UIColor *lightColor = [LoremIpsum lightColor];
+UIColor *darkColor = [LoremIpsum darkColor];
+UIColor *adaptiveColor = [LoremIpsum adaptiveColor];
 ```
 
 ### Images

--- a/Sources/LoremIpsum/include/LoremIpsum.h
+++ b/Sources/LoremIpsum/include/LoremIpsum.h
@@ -116,6 +116,26 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, nonatomic, readonly, strong) NSDate *date;
 
 ///-------------------------------
+/// @name Colors
+///-------------------------------
+
+#if TARGET_OS_IPHONE
+
+@property (nonatomic, strong, readonly) UIColor *lightColor;
+@property (nonatomic, strong, readonly) UIColor *darkColor;
+@property (nonatomic, strong, readonly) UIColor *adaptiveColor API_AVAILABLE(ios(13.0));
+@property (nonatomic, strong, readonly) UIColor *invertedAdaptiveColor API_AVAILABLE(ios(13.0));
+
+#elif TARGET_OS_MAC
+
+@property (nonatomic, strong, readonly) NSColor *lightColor;
+@property (nonatomic, strong, readonly) NSColor *darkColor;
+@property (nonatomic, strong, readonly) NSColor *adaptiveColor API_AVAILABLE(macos(10.15));
+@property (nonatomic, strong, readonly) NSColor *invertedAdaptiveColor API_AVAILABLE(macos(10.15));
+
+#endif
+
+///-------------------------------
 /// @name Images
 ///-------------------------------
 


### PR DESCRIPTION
Also:

- Use `arc4random_uniform()` instead of `arc4random()` (see https://stackoverflow.com/a/17640956/983912)
- Bump package to iOS 9 to remove Xcode 12 warning (Xcode 12 supports minimum iOS target of 9.0)

Closes #4