### PR TITLE
Raise iOS Deployment Target to iOS 10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     name: "LoremIpsum",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v10),
         .watchOS(.v2),
         .tvOS(.v9)
     ],


### PR DESCRIPTION
## What is this?

The changes in this PR raise the iOS Deployment target for the library to iOS 10 in order to silence an Xcode 13.4.1 warning relating to an unsupported deployment target.